### PR TITLE
Implement basic aging funcionality

### DIFF
--- a/definitions.c
+++ b/definitions.c
@@ -11,10 +11,10 @@ page_table_entry_t page_table[N_SLOTS_VM];
 static int8_t get_free_real_address() {
     for(int8_t i = 0; i < N_SLOTS_RM; i++) {
         if(real_memory[i].page.is_free) {
-            printf("Page %d is free\n", i);
+            //printf("Page %d is free\n", i);
             return i;
         }
-        printf("Page %d isn't free\n", i);
+        //printf("Page %d isn't free\n", i);
     }
     return -1;
 }
@@ -36,6 +36,24 @@ void init_pages_as_free() {
     }
 }
 
+// set referenced bit of all pages as 0 
+void unreference_all_pages() {
+    for(int8_t i = 0; i < N_SLOTS_RM; i++) {
+        real_memory[i].page.R = 0;
+    }
+}
+
+// set the virtual address that was mapped on the lru as unmapped
+void unmap_address(int8_t real_addr){
+    int i;
+    for(i = 0; i < N_SLOTS_VM; i++){
+        if(page_table[i].real_addr == real_addr){
+            page_table[i].is_mapped = false;
+            break;
+        }
+    }
+}
+
 int reference_page(int8_t addr) {
     if(addr >= N_SLOTS_VM) {
         // invalid virtual address
@@ -45,43 +63,64 @@ int reference_page(int8_t addr) {
     // lookup page table entry of given address
     page_table_entry_t pte = page_table[addr];
 
-    if(pte.is_mapped == true){
+    if(pte.is_mapped){
         // reference page
         // assuming it's on the real memory
-        real_memory[pte.real_addr].page.referenced_counter++; // update counter;
+        printf("Page in real address %d was referenced\n", pte.real_addr);
+
+        // update counter
+        if(real_memory[pte.real_addr].page.R == 1){
+            real_memory[pte.real_addr].page.referenced_counter /= 2; // update counter;
+            real_memory[pte.real_addr].page.referenced_counter += 128; // update counter;
+        }else{
+            real_memory[pte.real_addr].page.referenced_counter /=2 ; // update counter;
+        }
         real_memory[pte.real_addr].page.R = 1; // was recently referenced ! (in the last cycle)
+
     }else{
-        // page fault
+        /*if(is_on_swap(pte.real_addr)){
+            
+        }*/
+        // page miss
+        printf("Page Miss !\n");
         int8_t real_addr = get_free_real_address();// -1 se não achar
 
         if(real_addr == -1){//real memory is full
-            // page miss
 
-            printf("Page Miss !\n");
             
             // get a new swap address to recieve the oldest page
             int8_t swap_addr = get_free_swap_address();// tem que estar entre N_SLOTS_RM
             if(swap_addr == -1){
                 // :(
+                return -1;
             }
 
             // find lru page and puts it into swap
             int8_t liberated_adrr; //liberated address
             swap[swap_addr].page = lru_page(&liberated_adrr);
-            printf("The removed page went to swap[%d]\n", swap_addr);
-            printf("The liberated addr on the real memory was %d\n", liberated_adrr);
+            printf("Page mapped to %d\n", liberated_adrr);
+            printf("obs:The removed page went to swap[%d]\n", swap_addr);
+
+            // set the virtual address that was mapped on the lru as unmapped
+            unmap_address(liberated_adrr);
 
             // the freed address will recieve the new page
             real_memory[liberated_adrr].page.referenced_counter = 1;
             real_memory[liberated_adrr].page.R = 1; // was recently referenced ! (in the last cycle)
 
             pte.real_addr = liberated_adrr; // store it in the page table
-            pte.is_mapped = true;  
+            pte.is_mapped = 1;  
+            page_table[addr] = pte;
         }else{
             pte.real_addr = real_addr;
-            real_memory[pte.real_addr].page.referenced_counter++; // update counter
+            pte.is_mapped = 1;
+
+            real_memory[pte.real_addr].page.referenced_counter = 1;
             real_memory[pte.real_addr].page.R = 1; // was recently referenced ! (in the last cycle)
             real_memory[pte.real_addr].page.is_free = false; // set the page as linked to a virtual address
+
+            page_table[addr] = pte;//update page table entry
+            printf("Page mapped to %d\n", real_addr);
         }
     }
     return 0;

--- a/definitions.c
+++ b/definitions.c
@@ -7,9 +7,18 @@ mem_slot_t swap[N_SLOTS_SWAP];
 // process table stores the mapping between VM and RM
 page_table_entry_t page_table[N_SLOTS_VM];
 
-static int8_t get_free_real_address() {
-    for(int8_t i = 0; i < N_SLOTS_RM; i++) {
+static uint8_t get_free_real_address() {
+    for(uint8_t i = 0; i < N_SLOTS_RM; i++) {
         if(real_memory[i].page.is_free) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static uint8_t get_free_swap_address() {
+    for(uint8_t i = 0; i < N_SLOTS_RM; i++) {
+        if(swap[i].page.is_free) {
             return i;
         }
     }
@@ -63,6 +72,24 @@ int reference_page(uint8_t addr) {
 }
 
 
+// returns the last recently used page 
+// and changes lib_addr to the freed address
+// on the real memory
 page_t lru_page(uint8_t *lib_addr){
-    // [TODO]
+    int i, pi_counter = 0, lowest, i_lru = 0;
+    page_t lru;
+    for (i = 0; i < N_SLOTS_RM; i++){
+        pi_counter = real_memory[i].page.referenced_counter;
+        if(i == 0){
+            lowest = pi_counter;
+        }else{
+            if(pi_counter < lowest){
+                lowest = pi_counter;
+                i_lru = i;
+            }
+        }
+    }
+    *lib_addr = i_lru;
+    lru = real_memory[i_lru].page;
+    return lru;
 }

--- a/definitions.c
+++ b/definitions.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include "definitions.h"
 
@@ -7,17 +8,19 @@ mem_slot_t swap[N_SLOTS_SWAP];
 // process table stores the mapping between VM and RM
 page_table_entry_t page_table[N_SLOTS_VM];
 
-static uint8_t get_free_real_address() {
-    for(uint8_t i = 0; i < N_SLOTS_RM; i++) {
+static int8_t get_free_real_address() {
+    for(int8_t i = 0; i < N_SLOTS_RM; i++) {
         if(real_memory[i].page.is_free) {
+            printf("Page %d is free\n", i);
             return i;
         }
+        printf("Page %d isn't free\n", i);
     }
     return -1;
 }
 
-static uint8_t get_free_swap_address() {
-    for(uint8_t i = 0; i < N_SLOTS_RM; i++) {
+static int8_t get_free_swap_address() {
+    for(int8_t i = 0; i < N_SLOTS_RM; i++) {
         if(swap[i].page.is_free) {
             return i;
         }
@@ -25,12 +28,20 @@ static uint8_t get_free_swap_address() {
     return -1;
 }
 
-int reference_page(uint8_t addr) {
+// set all pages as free
+void init_pages_as_free() {
+    for(int8_t i = 0; i < N_SLOTS_RM; i++) {
+        real_memory[i].page.is_free = true;
+        swap[i].page.is_free = true;
+    }
+}
+
+int reference_page(int8_t addr) {
     if(addr >= N_SLOTS_VM) {
         // invalid virtual address
         return -1;
     }
-
+    
     // lookup page table entry of given address
     page_table_entry_t pte = page_table[addr];
 
@@ -41,20 +52,24 @@ int reference_page(uint8_t addr) {
         real_memory[pte.real_addr].page.R = 1; // was recently referenced ! (in the last cycle)
     }else{
         // page fault
-        uint8_t real_addr = get_free_real_address();// -1 se não achar
+        int8_t real_addr = get_free_real_address();// -1 se não achar
 
         if(real_addr == -1){//real memory is full
             // page miss
+
+            printf("Page Miss !\n");
             
             // get a new swap address to recieve the oldest page
-            uint8_t swap_addr = get_free_swap_address();// tem que estar entre N_SLOTS_RM
+            int8_t swap_addr = get_free_swap_address();// tem que estar entre N_SLOTS_RM
             if(swap_addr == -1){
                 // :(
             }
 
             // find lru page and puts it into swap
-            uint8_t liberated_adrr; //liberated address
+            int8_t liberated_adrr; //liberated address
             swap[swap_addr].page = lru_page(&liberated_adrr);
+            printf("The removed page went to swap[%d]\n", swap_addr);
+            printf("The liberated addr on the real memory was %d\n", liberated_adrr);
 
             // the freed address will recieve the new page
             real_memory[liberated_adrr].page.referenced_counter = 1;
@@ -66,6 +81,7 @@ int reference_page(uint8_t addr) {
             pte.real_addr = real_addr;
             real_memory[pte.real_addr].page.referenced_counter++; // update counter
             real_memory[pte.real_addr].page.R = 1; // was recently referenced ! (in the last cycle)
+            real_memory[pte.real_addr].page.is_free = false; // set the page as linked to a virtual address
         }
     }
     return 0;
@@ -75,7 +91,7 @@ int reference_page(uint8_t addr) {
 // returns the last recently used page 
 // and changes lib_addr to the freed address
 // on the real memory
-page_t lru_page(uint8_t *lib_addr){
+page_t lru_page(int8_t *lib_addr){
     int i, pi_counter = 0, lowest, i_lru = 0;
     page_t lru;
     for (i = 0; i < N_SLOTS_RM; i++){

--- a/definitions.h
+++ b/definitions.h
@@ -36,5 +36,6 @@ int reference_page(int8_t addr);
 // on the real memory
 page_t lru_page(int8_t *lib_addr);
 void init_pages_as_free();
+void unreference_all_pages();
 
 #endif // DEFINITIONS_H

--- a/definitions.h
+++ b/definitions.h
@@ -10,9 +10,7 @@
 typedef struct{
     uint8_t referenced_counter;
     bool R;// referenced bit
-    // true when the memory page is unused
-    bool is_free;
-
+    bool is_free;// true when the memory page is unused
 }page_t;
 
 typedef struct {

--- a/definitions.h
+++ b/definitions.h
@@ -8,7 +8,7 @@
 #define N_SLOTS_SWAP 8 // |SW| >= |VM| - |RM|
 
 typedef struct{
-    uint8_t referenced_counter;
+    int8_t referenced_counter;
     bool R;// referenced bit
     bool is_free;// true when the memory page is unused
 }page_t;
@@ -23,19 +23,18 @@ extern mem_slot_t swap[N_SLOTS_SWAP];
 
 typedef struct{
     bool is_mapped;
-    uint8_t real_addr; // between 0 and N_SLOTS_RM - 1
+    int8_t real_addr; // between 0 and N_SLOTS_RM - 1
 }page_table_entry_t;
 
 // process table stores the mapping between VM and RM
 extern page_table_entry_t page_table[N_SLOTS_VM];
 
-int reference_page(uint8_t addr);
+int reference_page(int8_t addr);
 
 // returns the last recently used page 
 // and changes lib_addr to the freed address
 // on the real memory
-page_t lru_page(uint8_t *lib_addr);
-
-
+page_t lru_page(int8_t *lib_addr);
+void init_pages_as_free();
 
 #endif // DEFINITIONS_H

--- a/main.c
+++ b/main.c
@@ -102,12 +102,11 @@ int main()
     int n_pages = 0;
     init_pages_as_free();
     while(n_pages < 100){
-        //page_t *new_page;
-        //new_page = malloc(sizeof(page_t));
-        //new_page->R = rand()%2;
+        unreference_all_pages();
+
         int v_addr = rand()%N_SLOTS_VM;
 
-        printf("Referencing page in virtual addr %d...\n", v_addr);
+        printf("\nReferencing page in virtual addr %d...\n", v_addr);
         int rv = reference_page(v_addr);
         if(rv == -1){
             printf("Invalid virtual address\n");

--- a/main.c
+++ b/main.c
@@ -100,19 +100,21 @@ int main()
     srand(time(NULL));
 
     int n_pages = 0;
-    while(n_pages < 5){
+    init_pages_as_free();
+    while(n_pages < 100){
         //page_t *new_page;
         //new_page = malloc(sizeof(page_t));
         //new_page->R = rand()%2;
         int v_addr = rand()%N_SLOTS_VM;
-        int rv = reference_page(v_addr);
+
         printf("Referencing page in virtual addr %d...\n", v_addr);
+        int rv = reference_page(v_addr);
         if(rv == -1){
             printf("Invalid virtual address\n");
             return 1;
         }
         n_pages++;
-        sleep(2);
+        sleep(1);
     }
     // mem_free_pages(); // free all memory pages
 

--- a/main.c
+++ b/main.c
@@ -105,8 +105,8 @@ int main()
         //new_page = malloc(sizeof(page_t));
         //new_page->R = rand()%2;
         int v_addr = rand()%N_SLOTS_VM;
-        printf("Referencing page in virtual addr %d...\n", v_addr);
         int rv = reference_page(v_addr);
+        printf("Referencing page in virtual addr %d...\n", v_addr);
         if(rv == -1){
             printf("Invalid virtual address\n");
             return 1;


### PR DESCRIPTION
The basics of the lru simulator are working!

Things we still need to decide / understand / implement :
- How pages that were sent to swap can be _referenced_ and _restored_;
- Maybe introduce the M _(modified)_ bit as a criteria to send removed pages to swap;
- Reference more than one page at each clock tick;
- Think about page _sets_ and whether they require all its pages to be sent to the swap together;